### PR TITLE
 ML Model Variable Updates - Adds More Varied Configurations

### DIFF
--- a/backend/controller/models.py
+++ b/backend/controller/models.py
@@ -590,9 +590,10 @@ class MlModelVariable(extensions.db.Model):
   """Model for ml model variable."""
   __tablename__ = 'ml_model_variables'
 
-  ml_model_id = Column(Integer, ForeignKey('ml_models.id'), primary_key=True)
-  name = Column(String(255), nullable=False, primary_key=True)
+  id = Column(Integer, primary_key=True, autoincrement=True)
+  ml_model_id = Column(Integer, ForeignKey('ml_models.id'), nullable=False)
   source = Column(String(255), nullable=False)
+  name = Column(String(255), nullable=False)
   role = Column(String(255), nullable=True)
   key = Column(String(255), nullable=True)
   comparison = Column(String(255), nullable=True)

--- a/backend/migrations/versions/420401efbf38_update_variables_pk.py
+++ b/backend/migrations/versions/420401efbf38_update_variables_pk.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Google Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ML models variables update to allow for variable reuse with different comparison values.
+
+Revision ID: 420401efbf38
+Revises: 8b95ad532329
+Create Date: 2024-05-29 19:44:46.732614
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '420401efbf38'
+down_revision = '8b95ad532329'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('ml_model_variables_ibfk_1', 'ml_model_variables', type_='foreignkey')
+    op.drop_constraint('PRIMARY', 'ml_model_variables', type_='primary')
+    with op.batch_alter_table('ml_model_variables', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('id', sa.Integer()))
+    op.create_primary_key('PRIMARY', 'ml_model_variables', ['id'])
+    op.execute('ALTER TABLE ml_model_variables MODIFY id INTEGER NOT NULL AUTO_INCREMENT;')
+    op.create_foreign_key(
+        'ml_model_variables_ibfk_1', 'ml_model_variables', 'ml_models',
+        ['ml_model_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('ml_model_variables_ibfk_1', 'ml_model_variables', type_='foreignkey')
+    op.drop_constraint('PRIMARY', 'ml_model_variables', type_='primary')
+    with op.batch_alter_table('ml_model_variables', schema=None) as batch_op:
+        batch_op.drop_column('id')
+    op.create_primary_key(
+        'PRIMARY', 'ml_model_variables',
+        ['ml_model_id', 'name'])
+    op.create_foreign_key(
+        'ml_model_variables_ibfk_1', 'ml_model_variables', 'ml_models',
+        ['ml_model_id'], ['id'])

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.html
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.html
@@ -162,6 +162,7 @@
                     </mat-option>
                   </mat-select>
                 </td>
+                <td *ngIf="!value(variable, 'names')" class="name"></td>
                 <td class="count" [hidden]="!value(variable, 'count')">
                   <mat-icon>bar_chart</mat-icon> {{ value(variable, 'count') }}
                 </td>
@@ -171,37 +172,60 @@
                     <mat-option *ngFor="let role of roles" [value]="role">{{ role | labelcase }}</mat-option>
                   </mat-select>
                 </td>
+                <td *ngIf="!value(variable, 'roles')" class="role"></td>
                 <td *ngIf="value(variable, 'parameters'); let parameters" class="key">
-                  <mat-select [placeholder]="value(variable, 'placeholder')" formControlName="key" (selectionChange)="refreshVariables()">
+                  <mat-select [placeholder]="value(variable, 'key_placeholder')" formControlName="key" (selectionChange)="refreshVariables()">
                     <mat-option [value]="null">----</mat-option>
                     <mat-option *ngFor="let parameter of parameters" [value]="parameter.key">{{ parameter.key }}</mat-option>
                   </mat-select>
                 </td>
+                <td *ngIf="!value(variable, 'parameters')" class="key"></td>
                 <td *ngIf="value(variable, 'key') && value(variable, 'comparisons'); let comparisons" class="comparison">
-                  <mat-select placeholder="Comparison" formControlName="comparison">
+                  <mat-select placeholder="Comparison *" formControlName="comparison">
+                    <mat-option [value]="null">----</mat-option>
                     <mat-option *ngFor="let comparison of comparisons" [value]="comparison.value">{{ comparison.label | labelcase }}</mat-option>
                   </mat-select>
                 </td>
+                <td *ngIf="!value(variable, 'key') || !value(variable, 'comparisons')" class="value"></td>
                 <td *ngIf="value(variable, 'key') && value(variable, 'comparisons')" class="value">
                   <mat-form-field>
                     <input matInput type="text" formControlName="value">
                   </mat-form-field>
                 </td>
-                <td class='hint' *ngIf="error(variable)">
+                <td *ngIf="!value(variable, 'key') || !value(variable, 'comparisons')" class="value"></td>
+                <td *ngIf="error(variable)" class='hint'>
                   <mat-icon class="tooltip-icon"
                             [matTooltip]="error(variable) | labelcase"
-                            matTooltipPosition="after"
+                            matTooltipPosition="above"
                             matTooltipClass="crmi-tooltip">
                     warning
                   </mat-icon>
                 </td>
-                <td class='hint' *ngIf="!error(variable) && value(variable, 'hint')">
+                <td *ngIf="!error(variable) && value(variable, 'hint')" class='hint'>
                   <mat-icon class="tooltip-icon"
                             [matTooltip]="value(variable, 'hint')"
-                            matTooltipPosition="after"
+                            matTooltipPosition="above"
                             matTooltipClass="crmi-tooltip">
                     help
                   </mat-icon>
+                </td>
+                <td *ngIf="!error(variable) && !value(variable, 'hint')" class='hint'></td>
+                <td class='remove'>
+                  <button mat-raised-button
+                          (click)="removeVariable(i)"
+                          type="button">
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td id="add-variable" colspan="999">
+                  <button mat-raised-button
+                          (click)="addVariable()"
+                          type="button"
+                          color="primary">
+                    Add
+                  </button>
                 </td>
               </tr>
             </tbody>
@@ -234,7 +258,12 @@
         <div *ngIf="type.isClassification" class="crmi-form-group">
           <label class="crmi-form-label">
             Number of Segments
-            <mat-icon class="tooltip-icon" title="Used when calculating conversion rates.">help</mat-icon>
+            <mat-icon class="tooltip-icon"
+                      matTooltip="Used when calculating conversion rates."
+                      matTooltipPosition="above"
+                      matTooltipClass="crmi-tooltip">
+              help
+            </mat-icon>
           </label>
           <mat-slider formControlName="conversionRateSegments" [min]="2" [max]="10" [step]="1" [thumbLabel]="true"></mat-slider>
           <span>{{ value('conversionRateSegments') }}</span>
@@ -261,8 +290,14 @@
           </div>
         </div>
 
+        <div *ngIf="errorMessage" class="crmi-form-message crmi-form-message-error">
+          <mat-icon class="tooltip-icon"
+                    matTooltipClass="crmi-tooltip">
+            warning
+          </mat-icon>
+          {{ errorMessage }}
+        </div>
         <div class="crmi-form-offset">
-          <div class="crmi-form-message crmi-form-message-error">{{ errorMessage }}</div>
           <button mat-raised-button
                   type="submit"
                   [disabled]="!mlModelForm.valid"

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.html
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.html
@@ -148,8 +148,20 @@
           <table>
             <tbody>
               <tr *ngFor="let variable of variables.controls; index as i" [formGroupName]="i">
-                <td class="source">{{ value(variable, 'source') | labelcase }}</td>
-                <td>{{ value(variable, 'name') }}</td>
+                <td class="source">
+                  <mat-select placeholder="Source" formControlName="source" (selectionChange)="refreshVariables()">
+                    <mat-option *ngFor="let source of value(variable, 'sources')" [value]="source">
+                      {{ source | labelcase }}
+                    </mat-option>
+                  </mat-select>
+                </td>
+                <td *ngIf="value(variable, 'names'); let names" class="name">
+                  <mat-select placeholder="Variable" formControlName="name" (selectionChange)="refreshVariables()">
+                    <mat-option *ngFor="let name of names" [value]="name">
+                      {{ name }}
+                    </mat-option>
+                  </mat-select>
+                </td>
                 <td class="count" [hidden]="!value(variable, 'count')">
                   <mat-icon>bar_chart</mat-icon> {{ value(variable, 'count') }}
                 </td>

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.html
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.html
@@ -155,17 +155,22 @@
                     </mat-option>
                   </mat-select>
                 </td>
-                <td *ngIf="value(variable, 'names'); let names" class="name">
-                  <mat-select placeholder="Variable" formControlName="name" (selectionChange)="refreshVariables()">
-                    <mat-option *ngFor="let name of names" [value]="name">
-                      {{ name }}
+                <td *ngIf="value(variable, 'list'); let list" class="name">
+                  <mat-select placeholder="Variable"
+                              formControlName="name"
+                              (selectionChange)="refreshVariables()"
+                              (opened)="variableSelectOpen = i"
+                              (blur)="variableSelectOpen = -1">
+                    <mat-option *ngFor="let variable of list" [value]="variable.name">
+                      {{ variable.name }}
+                      <span *ngIf="variableSelectOpen === i && variable.count"
+                            style="float:right; font-size:10px">
+                        {{ variable.count }}
+                      </span>
                     </mat-option>
                   </mat-select>
                 </td>
-                <td *ngIf="!value(variable, 'names')" class="name"></td>
-                <td class="count" [hidden]="!value(variable, 'count')">
-                  <mat-icon>bar_chart</mat-icon> {{ value(variable, 'count') }}
-                </td>
+                <td *ngIf="!value(variable, 'list')" class="name"></td>
                 <td *ngIf="value(variable, 'roles'); let roles" class="role">
                   <mat-select placeholder="Include As" formControlName="role" (selectionChange)="refreshVariables()">
                     <mat-option [value]="null">----</mat-option>

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.sass
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.sass
@@ -3,9 +3,10 @@
   flex-direction: row
   position: relative
   align-items: center
-  margin-right: 90px
+  margin: 0px 40px
   .crmi-form-label
     padding-right: 20px
+    width: 165px
   .mat-form-label
     flex-grow: 0
   .mat-form-field, .mat-select, .mat-slider
@@ -22,6 +23,11 @@
     margin-left: 28px
   .mat-form-field + .mat-form-field
     margin-left: 28px
+
+.crmi-form-message-error
+  padding: 20px
+  border: 1px solid #c51162
+  border-radius: 4px
 
 .option-description
   display: block
@@ -107,7 +113,7 @@
 #variables
   table
     margin: 20px 0px
-    padding: 10px
+    padding: 20px 10px
     border: 1px solid rgba(0, 0, 0, 0.3)
     border-radius: 4px
     flex-grow: 1
@@ -115,12 +121,14 @@
     border-spacing: 10px 0px
     font-size: 14px
     tr
+      td#add-variable
+        padding-top: 20px
       td .mat-select
         margin: 5px
       td.name, td.source
-        width: 150px
+        width: 130px
         .mat-select
-          width: 150px
+          width: 130px
       td.role
         text-align: left
         .mat-select
@@ -133,6 +141,7 @@
           width: calc(100% - 20px)
       td.value
         .mat-form-field
+          width: 120px
           text-align: center
       td.count
         text-align: right
@@ -150,6 +159,16 @@
       td.hint
         padding: 0px
         width: 27px
+      td.remove
+        padding: 0px
+        width: 27px
+        text-align: right
+        button
+          border: none
+          box-shadow: none
+          width: 27px
+          min-width: 27px
+          padding: 0px
 
 
 #label

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.sass
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.sass
@@ -132,8 +132,8 @@
       td.role
         text-align: left
         .mat-select
-          margin-left: 20px
-          width: calc(100% - 40px)
+          margin-left: 0px
+          width: calc(100% - 20px)
       td.key, td.comparison
         text-align: left
         .mat-select
@@ -143,19 +143,6 @@
         .mat-form-field
           width: 120px
           text-align: center
-      td.count
-        text-align: right
-        font-size: 12px
-        min-width: 85px
-        max-width: 85px
-        .mat-icon
-          font-size: 14px
-          font-weight: 700
-          vertical-align: middle
-          padding-top: 8px
-      td.count[hidden]
-        display: block
-        visibility: hidden
       td.hint
         padding: 0px
         width: 27px

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.sass
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.sass
@@ -29,11 +29,8 @@
   border: 1px solid #c51162
   border-radius: 4px
 
-.option-description
-  display: block
-  float: right
-  font-size: 11px
-  font-weight: 600
+.crmi-form-offset
+  padding-left: 220px
 
 .notice
   background-color: #c51162
@@ -194,7 +191,7 @@
   padding-left: 3px
 
 button[type='submit']
-  margin-top: 50px
+  margin: 50px 0px
 
 button:disabled
   cursor: not-allowed

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.sass
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.sass
@@ -114,41 +114,42 @@
     height: auto
     border-spacing: 10px 0px
     font-size: 14px
-  table tr td .mat-select
-    margin: 5px
-  table tr td.source
-    color: rgba(0, 0, 0, 0.6)
-    font-weight: 500
-    font-size: 12px
-    width: 300px
-  table tr td.role
-    text-align: left
-    .mat-select
-      margin-left: 20px
-      width: calc(100% - 40px)
-  table tr td.key, table tr td.comparison
-    text-align: left
-    .mat-select
-      margin-left: 0px
-      width: calc(100% - 20px)
-  table tr td.value
-    .mat-form-field
-      text-align: center
-  table tr td.count
-    text-align: right
-    font-size: 12px
-    width: 300px
-    .mat-icon
-      font-size: 14px
-      font-weight: 700
-      vertical-align: middle
-      padding-top: 8px
-  table tr td.count[hidden]
-    display: block
-    visibility: hidden
-  table tr td.hint
-    padding: 0px
-    width: 27px
+    tr
+      td .mat-select
+        margin: 5px
+      td.name, td.source
+        width: 150px
+        .mat-select
+          width: 150px
+      td.role
+        text-align: left
+        .mat-select
+          margin-left: 20px
+          width: calc(100% - 40px)
+      td.key, td.comparison
+        text-align: left
+        .mat-select
+          margin-left: 0px
+          width: calc(100% - 20px)
+      td.value
+        .mat-form-field
+          text-align: center
+      td.count
+        text-align: right
+        font-size: 12px
+        min-width: 85px
+        max-width: 85px
+        .mat-icon
+          font-size: 14px
+          font-weight: 700
+          vertical-align: middle
+          padding-top: 8px
+      td.count[hidden]
+        display: block
+        visibility: hidden
+      td.hint
+        padding: 0px
+        width: 27px
 
 
 #label

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.ts
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.ts
@@ -315,6 +315,33 @@ export class MlModelFormComponent implements OnInit {
   }
 
   /**
+   * Adds a new variable form control to the form array "variables". This creates a new entry where
+   * the user can start to fill in the necessary fields for defining a variable and how the backend
+   * should use/add that variable to the model via the templates.
+   */
+  addVariable() {
+    const variables: Variable[] = this.getVariables();
+    const variableSources: string[] = variables.map(v => v.source).filter((s, i, a) => a.indexOf(s) === i);
+
+    const formVariables = this.mlModelForm.get('variables') as UntypedFormArray;
+    formVariables.push(this._fb.group({
+      sources: [variableSources],
+      source: [null]
+    }));
+  }
+
+  /**
+   * Remove a variable form control to the form array "variables". This entry will no longer show up
+   * in the list of variables for the user to modify/adjust settings for.
+   *
+   * @param index The index to remove from the "variables" form array.
+   */
+  removeVariable(index: number) {
+    const formVariables = this.mlModelForm.get('variables') as UntypedFormArray;
+    formVariables.removeAt(index);
+  }
+
+  /**
    * Get variables (feature, label, and other options) from GA4 Events and First Party tables in BigQuery.
    */
   async fetchVariables() {
@@ -367,91 +394,91 @@ export class MlModelFormComponent implements OnInit {
     const comparisons = Object.keys(Comparison).map(c => {
       return { value: Comparison[c], label: c };
     });
+
+    if (!existingVariables.length) {
+      this.addVariable();
+      return;
+    }
+
     let controls = [];
 
-    if (existingVariables.length) {
-      for (let existingVariable of existingVariables) {
-        const matchingVariables = variables.filter(v => v.source === existingVariable.source);
-        if (!matchingVariables.length) {
-          continue;
-        }
-
-        let variable = matchingVariables.find(v => v.name === existingVariable.name);
-        if (!variable) {
-          controls.push(this._fb.group({
-            sources: [variableSources],
-            source: [existingVariable.source],
-            names: [variables.filter(v => v.source === existingVariable.source).map(v => v.name)],
-            name: [null],
-          }));
-          continue;
-        }
-
-        variable.roles = this.getApplicableVariableRoles(existingVariables, variable);
-        variable.role = existingVariable && variable.roles.includes(existingVariable.role) ? existingVariable.role : null;
-        variable.comparison = existingVariable ? existingVariable.comparison : null;
-        variable.value = existingVariable ? existingVariable.value : null;
-        variable.key = null;
-        variable.key_required = false;
-        variable.hint = null;
-
-        if (existingVariable && existingVariable.key && variable.role) {
-          variable.key = existingVariable.key;
-          variable.value_type = variable.parameters.find(p => p.key === variable.key).value_type;
-        }
-
-        if (variable.role === Role.FEATURE && variable.source === Source.GOOGLE_ANALYTICS) {
-          variable.comparisons = comparisons;
-          variable.key_required = false;
-          if (!variable.key) {
-            variable.comparison = null;
-            variable.value = null;
-          }
-        }
-
-        if (variable.role === Role.LABEL && variable.source === Source.GOOGLE_ANALYTICS) {
-          variable.key_required = true;
-          variable.hint = `${isRegressionModel ? 'First value' : 'Trigger event'} will be automatically derived from the first occurrence of this event if not assigned.`;
-        }
-
-        if ([Role.FIRST_VALUE, Role.TRIGGER_EVENT].includes(variable.role) && variable.source === Source.GOOGLE_ANALYTICS) {
-          variable.key_required = true;
-          variable.hint = 'Trigger date will be automatically derived from the first date associated with this event.';
-        }
-
-        if (variable.role === Role.GCLID) {
-          variable.hint = 'Trigger date field will be used as the datetime for the conversion sent to Google Ads.';
-        }
-
-        const control = this._fb.group({
-          sources: [variableSources],
-          source: [variable.source, this.enumValidator(Source)],
-          names: [variables.filter(v => v.source === existingVariable.source).map(v => v.name)],
-          name: [variable.name],
-          placeholder: 'Key' + (variable.key_required ? ' *' : ''),
-          count: [variable.count],
-          roles: [variable.roles],
-          role: [variable.role, this.enumValidator(Role)],
-          parameters: [variable.key_required || variable.comparisons ? variable.parameters : null],
-          key: [
-            variable.key,
-            variable.key_required ? [Validators.required] : []
-          ],
-          comparisons: [variable.comparisons],
-          comparison: [variable.comparison, this.enumValidator(Comparison)],
-          value: [variable.value],
-          value_type: [variable.value_type],
-          hint: variable.hint
-        });
-
-        control.setValidators(this.variableValidator(existingVariables));
-        controls.push(control);
+    for (let existingVariable of existingVariables) {
+      const matchingVariables = variables.filter(v => v.source === existingVariable.source);
+      if (!matchingVariables.length) {
+        continue;
       }
-    } else {
-      controls.push(this._fb.group({
+
+      let variable = matchingVariables.find(v => v.name === existingVariable.name);
+      if (!variable) {
+        controls.push(this._fb.group({
+          sources: [variableSources],
+          source: [existingVariable.source],
+          names: [variables.filter(v => v.source === existingVariable.source).map(v => v.name)],
+          name: [null],
+        }));
+        continue;
+      }
+
+      variable.roles = this.getApplicableVariableRoles(existingVariables, variable);
+      variable.role = existingVariable && variable.roles.includes(existingVariable.role) ? existingVariable.role : null;
+      variable.comparisons = null;
+      variable.comparison = null;
+      variable.value = null;
+      variable.key = null;
+      variable.key_required = false;
+      variable.hint = null;
+
+      if (existingVariable && existingVariable.key && variable.role) {
+        variable.key = existingVariable.key;
+        variable.value_type = variable.parameters.find(p => p.key === variable.key).value_type;
+      }
+
+      if (variable.role === Role.FEATURE && variable.source === Source.GOOGLE_ANALYTICS) {
+        variable.comparisons = comparisons;
+        variable.key_required = false;
+        if (variable.key && existingVariable) {
+          variable.comparison = existingVariable.comparison;
+          variable.value = existingVariable.value;
+        }
+      }
+
+      if (variable.role === Role.LABEL && variable.source === Source.GOOGLE_ANALYTICS) {
+        variable.key_required = true;
+        variable.hint = `${isRegressionModel ? 'First value' : 'Trigger event'} will be automatically derived from the first occurrence of this event if not assigned.`;
+      }
+
+      if ([Role.FIRST_VALUE, Role.TRIGGER_EVENT].includes(variable.role) && variable.source === Source.GOOGLE_ANALYTICS) {
+        variable.key_required = true;
+        variable.hint = 'Trigger date will be automatically derived from the first date associated with this event.';
+      }
+
+      if (variable.role === Role.GCLID) {
+        variable.hint = 'Trigger date field will be used as the datetime for the conversion sent to Google Ads.';
+      }
+
+      const control = this._fb.group({
         sources: [variableSources],
-        source: [null]
-      }));
+        source: [variable.source, this.enumValidator(Source)],
+        names: [variables.filter(v => v.source === existingVariable.source).map(v => v.name)],
+        name: [variable.name],
+        key_placeholder: 'Key' + (variable.key_required ? ' *' : ''),
+        count: [variable.count],
+        roles: [variable.roles],
+        role: [variable.role, this.enumValidator(Role)],
+        parameters: [variable.key_required || variable.comparisons ? variable.parameters : null],
+        key: [
+          variable.key,
+          variable.key_required ? [Validators.required] : []
+        ],
+        comparisons: [variable.comparisons],
+        comparison: [variable.comparison, this.enumValidator(Comparison)],
+        value: [variable.value],
+        value_type: [variable.value_type],
+        hint: variable.hint
+      });
+
+      control.setValidators(this.variableValidator(existingVariables));
+      controls.push(control);
     }
 
     this.mlModelForm.setControl('variables', this._fb.array(controls));
@@ -624,6 +651,20 @@ export class MlModelFormComponent implements OnInit {
   }
 
   /**
+   * Validate the ml model object to ensure everything provided by the user meets at least
+   * the minimum requirements to build the model out properly.
+   *
+   * @throws Errors that encapsulate the reason for validation failures.
+   */
+  validateMlModel() {
+    const featuresSet = this.mlModel.variables.filter(v => v.role === Role.FEATURE).length >= 2;
+    const labelSet = this.mlModel.variables.filter(v => v.role === Role.LABEL).length === 1;
+    if (!featuresSet || !labelSet) {
+      throw 'At least 2 features and 1 label must be added/selected from the list of variables.';
+    }
+  }
+
+  /**
    * Update the ml model object using the form data and send it to the backend to persist.
    */
   async save() {
@@ -631,6 +672,8 @@ export class MlModelFormComponent implements OnInit {
     this.prepareSaveMlModel();
 
     try {
+      this.validateMlModel();
+
       if (this.mlModel.id) {
         await this.mlModelsService.update(this.mlModel);
         this.router.navigate(['ml-models', this.mlModel.id]);
@@ -687,6 +730,18 @@ export class MlModelFormComponent implements OnInit {
           const variablesWithRole = existingVariables.filter(v => v.role === variableRole);
           if (variablesWithRole.length > 1) {
             return {cannotAssignThisRoleToMultipleVariables: true};
+          }
+        } else {
+          const key = control.get('key').value;
+          const comparison = control.get('comparison').value;
+          const value = control.get('value').value;
+
+          if (key && !comparison) {
+            return {comparisonRequiredWhenKeySelected: true}
+          }
+
+          if (comparison && !value) {
+            return {valueRequiredForComparison: true}
           }
         }
       } else {

--- a/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.ts
+++ b/frontend/src/app/ml-models/ml-model-form/ml-model-form.component.ts
@@ -45,6 +45,7 @@ export class MlModelFormComponent implements OnInit {
   destinations: string[];
   cachedVariables: Variable[] = [];
   fetchingVariables: boolean = false;
+  variableSelectOpen: number = -1;
 
   constructor(
     private _fb: UntypedFormBuilder,
@@ -459,10 +460,9 @@ export class MlModelFormComponent implements OnInit {
       const control = this._fb.group({
         sources: [variableSources],
         source: [variable.source, this.enumValidator(Source)],
-        names: [variables.filter(v => v.source === existingVariable.source).map(v => v.name)],
+        list: [variables.filter(v => v.source === existingVariable.source).map(v => { return {name: v.name, count: v.count} })],
         name: [variable.name],
         key_placeholder: 'Key' + (variable.key_required ? ' *' : ''),
-        count: [variable.count],
         roles: [variable.roles],
         role: [variable.role, this.enumValidator(Role)],
         parameters: [variable.key_required || variable.comparisons ? variable.parameters : null],


### PR DESCRIPTION
Allows for the use of the same GA4 event with different key<->comparison pairings as individual features.
An example of this would be if you wanted to use the same event, but different keys within that event as features or if you wanted to use the same event and key, but use different comparisons (say to target two different pages) such that the page_location of that event is what defines the feature.