### PR TITLE
BigQuery Worker Wait Adjustments

### DIFF
--- a/backend/jobs/workers/bigquery/bq_waiter.py
+++ b/backend/jobs/workers/bigquery/bq_waiter.py
@@ -24,11 +24,13 @@ class BQWaiter(bq_worker.BQWorker):
 
   def _execute(self):
     client = self._get_client()
-    job = client.get_job(self._params['job_id'])
+    job = client.get_job(
+      job_id=self._params['job_id'],
+      location=self._params['location'])
     if job.error_result:
       raise worker.WorkerException(job.error_result['message'])
     if not job.done():
       self.log_info(f'Current BigQuery job state: {job.state}')
-      self._enqueue('BQWaiter', {'job_id': job.job_id}, 60)
+      self._enqueue('BQWaiter', {'job_id': job.job_id, 'location': job.location}, 60)
     else:
       self.log_info('Finished successfully!')

--- a/backend/jobs/workers/bigquery/bq_waiter.py
+++ b/backend/jobs/workers/bigquery/bq_waiter.py
@@ -25,9 +25,10 @@ class BQWaiter(bq_worker.BQWorker):
   def _execute(self):
     client = self._get_client()
     job = client.get_job(self._params['job_id'])
-    if job.error_result is not None:
+    if job.error_result:
       raise worker.WorkerException(job.error_result['message'])
-    if job.state != 'DONE':
-      self._enqueue('BQWaiter', {'job_id': self._params['job_id']}, 60)
+    if not job.done():
+      self.log_info(f'Current BigQuery job state: {job.state}')
+      self._enqueue('BQWaiter', {'job_id': job.job_id}, 60)
     else:
       self.log_info('Finished successfully!')

--- a/backend/jobs/workers/bigquery/bq_worker.py
+++ b/backend/jobs/workers/bigquery/bq_worker.py
@@ -68,16 +68,8 @@ class BQWorker(worker.Worker):
 
   def _wait(self, job):
     """Waits for job completion and relays to BQWaiter if it takes too long."""
-    delay = 5
-    waiting_time = 5
-    time.sleep(delay)
-    while not job.done():
-      if waiting_time > 300:  # Once 5 minutes have passed, spawn BQWaiter.
-        self._enqueue('BQWaiter', {'job_id': job.job_id}, 60)
-        return
-      if delay < 30:
-        delay = [5, 10, 15, 20, 30][int(waiting_time / 60)]
-      time.sleep(delay)
-      waiting_time += delay
-    if job.error_result is not None:
+    time.sleep(5)
+    if job.error_result:
       raise worker.WorkerException(job.error_result['message'])
+    if not job.done():
+      self._enqueue('BQWaiter', {'job_id': job.job_id}, 30)

--- a/backend/jobs/workers/bigquery/bq_worker.py
+++ b/backend/jobs/workers/bigquery/bq_worker.py
@@ -25,7 +25,7 @@ from jobs.workers import worker
 # Param name used to specify a BQ project ID
 BQ_PROJECT_ID_PARAM_NAME = 'bq_project_id'
 
-# Param name used to specify a BQ data set name
+# Param name used to specify a BQ dataset name
 BQ_DATASET_NAME_PARAM_NAME = 'bq_dataset_id'
 
 # Param name used to specify a BQ table name
@@ -50,8 +50,7 @@ class BQWorker(worker.Worker):
         client_info = ClientInfo(user_agent='cloud-solutions/crmint-usage-v3')
     return bigquery.Client(
       client_options={'scopes': self._SCOPES},
-      client_info=client_info,
-    )
+      client_info=client_info)
 
   def _get_prefix(self):
     return f'{self._pipeline_id}_{self._job_id}_{self.__class__.__name__}'
@@ -72,4 +71,4 @@ class BQWorker(worker.Worker):
     if job.error_result:
       raise worker.WorkerException(job.error_result['message'])
     if not job.done():
-      self._enqueue('BQWaiter', {'job_id': job.job_id}, 30)
+      self._enqueue('BQWaiter', {'job_id': job.job_id, 'location': job.location}, 30)

--- a/backend/tests/jobs/unit/workers/bq_waiter_tests.py
+++ b/backend/tests/jobs/unit/workers/bq_waiter_tests.py
@@ -29,10 +29,11 @@ class BQWaiterTest(parameterized.TestCase):
         'logger_credentials': _make_credentials(),
     }
     worker_inst = bq_waiter.BQWaiter(
-        {'job_id': 'JOBID',}, 1, 1, **logging_creds)
+        {'job_id': 'JOBID', 'location': 'US'}, 1, 1, **logging_creds)
     mock_job = mock.create_autospec(
         bigquery.job.QueryJob, instance=True, spec_set=True)
     mock_job.job_id = 'JOBID'
+    mock_job.location = 'US'
     mock_job.error_result = None
     mock_job.state = job_status
     mock_job.done.return_value = not enqueue_called
@@ -54,10 +55,11 @@ class BQWaiterTest(parameterized.TestCase):
             spec_set=True))
     self.enter_context(mock.patch.object(worker_inst, '_log', autospec=True))
     worker_inst._execute()
+    mock_client.get_job.assert_called_with(job_id='JOBID', location='US')
     if enqueue_called:
       patched_enqueue.assert_called_once()
       self.assertEqual(patched_enqueue.call_args[0][0], 'BQWaiter')
-      self.assertEqual(patched_enqueue.call_args[0][1], {'job_id': 'JOBID'})
+      self.assertEqual(patched_enqueue.call_args[0][1], {'job_id': 'JOBID', 'location': 'US'})
     else:
       patched_enqueue.assert_not_called()
 
@@ -78,7 +80,7 @@ class BQWaiterTest(parameterized.TestCase):
               autospec=True,
               spec_set=True))
       worker_inst = bq_waiter.BQWaiter(
-          {'job_id': 'JOBID',}, 1, 1,
+          {'job_id': 'JOBID', 'location': 'US'}, 1, 1,
           logger_project='PROJECT',
           logger_credentials=_make_credentials())
       worker_inst._execute()

--- a/backend/tests/jobs/unit/workers/bq_waiter_tests.py
+++ b/backend/tests/jobs/unit/workers/bq_waiter_tests.py
@@ -32,8 +32,10 @@ class BQWaiterTest(parameterized.TestCase):
         {'job_id': 'JOBID',}, 1, 1, **logging_creds)
     mock_job = mock.create_autospec(
         bigquery.job.QueryJob, instance=True, spec_set=True)
+    mock_job.job_id = 'JOBID'
     mock_job.error_result = None
     mock_job.state = job_status
+    mock_job.done.return_value = not enqueue_called
     mock_client = mock.create_autospec(
         bigquery.Client, instance=True, spec_set=True)
     mock_client.get_job.return_value = mock_job


### PR DESCRIPTION
Removes unnecessary exponential backoff as it's max wait was 5 minutes as written until it kicked off a waiter that polled every minute. The logic has been simplified to run, if it's not complete within 5 seconds then queue it for the waiter job to pick it up again in 30 seconds, and if the waiter job finds it's still incomplete it will queue it for another minute. It checks for errors before queueing it in any situation.

Also, this adds location (where the job was originally run) to the queue message so that when it's picked up it will look for the job in that location and none others. There was an issue where in some instances this was choosing the wrong region or polling both regions for the job_id which returned an error for one of them and threw off the logic.